### PR TITLE
Modern CMake approach for tsimd

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,14 +26,24 @@
 # CMake configuration
 ##############################################################
 
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.2)
 
 project(tsimd)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake")
 include(tsimd)
 
+add_library(tsimd INTERFACE)
+target_include_directories(tsimd INTERFACE
+	$<INSTALL_INTERFACE:include/tsimd>)
+
 install(DIRECTORY tsimd DESTINATION include)
+install(TARGETS tsimd
+	EXPORT tsimdConfig
+	RUNTIME DESTINATION bin/tsimd
+	ARCHIVE DESTINATION lib/tsimd
+	LIBRARY DESTINATION lib/tsimd)
+install(EXPORT tsimdConfig DESTINATION lib/cmake/tsimd)
 
 ##############################################################
 # Build tests and examples


### PR DESCRIPTION
I've updated the build system of ttk to follow a modern CMake approach, where tsimd is exported as an interface library, i.e. we have nothing to "compile" since it's header only but just set some target properties needed by clients of the code.

I also ported micro-packet over to tsimd on the [micro-packet/tsimd branch](https://github.com/Twinklebear/micro-packet/tree/tsimd) and ran some comparison benchmarks on my desktop.

CPU: Intel i7-5930k
Compiler: gcc (Ubuntu 6.3.0-12ubuntu2) 6.3.0 20170406

master branch (hand-written intrinsics):
```
max: 1894ms
min: 1868ms
median: 1878ms
median abs dev: 3ms
mean: 1877ms
std dev: 4ms
# of samples: 64
```

psimd branch:
```
max: 3475ms
min: 3375ms
median: 3412ms
median abs dev: 24ms
mean: 3414ms
std dev: 27ms
# of samples: 36
```

tsimd branch:
```
max: 2807ms
min: 2697ms
median: 2742ms
median abs dev: 23ms
mean: 2739ms
std dev: 28ms
# of samples: 44
```